### PR TITLE
Fix e.address is not a func 

### DIFF
--- a/packages/aeproject-cli/aeproject-node/node.js
+++ b/packages/aeproject-cli/aeproject-node/node.js
@@ -51,7 +51,6 @@ async function fundWallets (nodeIp) {
     let walletIndex = 0;
 
     let client = await utils.getClient(network);
-    client.addAccount(config.keyPair)
     await printBeneficiaryKey(client);
     for (let wallet in defaultWallets) {
         await fundWallet(client, defaultWallets[wallet].publicKey)


### PR DESCRIPTION
we have been passed a 'keyPair' but 'addAccount()' expects 'Account instance' https://github.com/aeternity/aepp-sdk-js/blob/e055271609cb0bc31093b778f4766ddd6a5136bf/es/accounts.js#LC82