### PR TITLE
move toggleLoader into start, add one more 'possible error'

### DIFF
--- a/packages/aeproject-cli/aeproject-env/EnvService.js
+++ b/packages/aeproject-cli/aeproject-env/EnvService.js
@@ -54,7 +54,10 @@ const DefaultColumnVariable = 'export COLUMNS=1000';
 const POSSIBLE_ERRORS = [
     'port is already allocated',
     'address already in use',
-    'request canceled'
+    // messages when docker is blocked by firewall
+    'request canceled',
+    'Temporary failure in name resolution',
+    'registry-1.docker.io'
 ]
 
 class EnvService {

--- a/packages/aeproject-cli/aeproject-env/EnvService.js
+++ b/packages/aeproject-cli/aeproject-env/EnvService.js
@@ -57,7 +57,8 @@ const POSSIBLE_ERRORS = [
     // messages when docker is blocked by firewall
     'request canceled',
     'Temporary failure in name resolution',
-    'registry-1.docker.io'
+    'registry-1.docker.io',
+    'forbidden by its access permissions'
 ]
 
 class EnvService {

--- a/packages/aeproject-cli/aeproject-env/EnvService.js
+++ b/packages/aeproject-cli/aeproject-env/EnvService.js
@@ -54,6 +54,7 @@ const DefaultColumnVariable = 'export COLUMNS=1000';
 const POSSIBLE_ERRORS = [
     'port is already allocated',
     'address already in use',
+    'not found',
     // messages when docker is blocked by firewall
     'request canceled',
     'Temporary failure in name resolution',
@@ -160,6 +161,7 @@ class EnvService {
         if (runCommand.stderr) {
             runCommand.stderr.on('data', (data) => {
                 errorMessage += data.toString();
+                console.log(data.toString());
             });
         }
 
@@ -275,7 +277,7 @@ class EnvService {
     }
 
     async isImageRunning (image, options) {
-
+        
         try {
             let running = false;
 
@@ -296,7 +298,7 @@ class EnvService {
 
             return running;
         } catch (error) {
-
+            
             if (this.checkForMissingDirectory(error)) {
                 return false;
             } 

--- a/packages/aeproject-cli/aeproject-env/env/compiler/compiler.js
+++ b/packages/aeproject-cli/aeproject-env/env/compiler/compiler.js
@@ -75,9 +75,7 @@ class Compiler extends EnvService {
 
             super.printStarMsg()
 
-            let startingCompilerSpawn = super.start();
-
-            await super.toggleLoader(startingCompilerSpawn, compilerImage)
+            await super.start(compilerImage);
 
             super.printSuccessMsg()
 

--- a/packages/aeproject-cli/aeproject-env/env/env.js
+++ b/packages/aeproject-cli/aeproject-env/env/env.js
@@ -95,11 +95,9 @@ class Env extends EnvService {
 
         try {
             super.printStarMsg()
-            
-            let startingNodeSpawn = super.start();
 
-            await super.toggleLoader(startingNodeSpawn, dockerImage)
-            
+            await super.start(dockerImage);
+
             super.printSuccessMsg()
             
             if (option.windows) {

--- a/packages/aeproject-cli/aeproject-env/env/node/node.js
+++ b/packages/aeproject-cli/aeproject-env/env/node/node.js
@@ -76,9 +76,7 @@ class Node extends EnvService {
 
             super.printStarMsg()
 
-            let startingNodeSpawn = super.start();
-
-            await super.toggleLoader(startingNodeSpawn, dockerImage)
+            await super.start(dockerImage);
 
             super.printSuccessMsg()
 


### PR DESCRIPTION
returned child-process cannot be passed as param that why the processing of 'on('data')' was moved to start. Added one more 'possible error" that is thrown by docker when it tries to pull some image.